### PR TITLE
Update branding to Raising the Game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rise to Greatness – Women’s Sports Scoreboard
+# Raising the Game – Women’s Sports Scoreboard
 
 A freshly rebuilt Next.js app that surfaces live scores for the WNBA, NWSL, and PWHL using free ESPN endpoints. The project is designed for the MVP outlined in our planning chat and keeps the stack lean so it runs anywhere—including GitHub Codespaces.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
-  title: "Rise to Greatness Scores",
+  title: "Raising the Game Scores",
   description: "Live scores across the WNBA, NWSL, and PWHL in one place.",
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-4 pb-16 pt-12 sm:px-6 lg:px-8">
         <header className="space-y-4">
           <p className="text-sm uppercase tracking-[0.35em] text-accent-200">
-            Rise to Greatness
+            Raising the Game
           </p>
           <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
             Women&apos;s Sports Scoreboard


### PR DESCRIPTION
## Summary
- update the site metadata to use the Raising the Game name
- refresh the homepage badge and README to reflect the new branding

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dd8266df90832ebcc8acdd2e972b99