### PR TITLE
Add league branding and typography updates

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,18 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Archivo, Inter, Rajdhani } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+const archivo = Archivo({
+  subsets: ["latin"],
+  variable: "--font-heading",
+  weight: ["500", "600", "700"],
+});
+const rajdhani = Rajdhani({
+  subsets: ["latin"],
+  variable: "--font-score",
+  weight: ["500", "600", "700"],
+});
 
 export const metadata: Metadata = {
   title: "Raising the Game Scores",
@@ -12,7 +22,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="bg-background text-white">
-      <body className={`${inter.variable} font-sans bg-background text-white antialiased`}>{children}</body>
+      <body
+        className={`${inter.variable} ${archivo.variable} ${rajdhani.variable} font-sans bg-background text-white antialiased`}
+      >
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/scoreboard-view.tsx
+++ b/components/scoreboard-view.tsx
@@ -1,7 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { DEFAULT_LEAGUE, LEAGUES, LeagueKey } from "@/lib/leagues";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
+import {
+  DEFAULT_LEAGUE,
+  LEAGUES,
+  type LeagueBrand,
+  type LeagueKey,
+} from "@/lib/leagues";
 
 interface ScoreboardResponse {
   league: LeagueKey;
@@ -48,6 +59,7 @@ export function ScoreboardView({ initialLeague = DEFAULT_LEAGUE }: ScoreboardVie
   const [error, setError] = useState<string | null>(null);
   const [refreshInterval, setRefreshInterval] = useState<number>(180);
   const [isBackgroundRefresh, setIsBackgroundRefresh] = useState(false);
+  const activeBrand = LEAGUES[selectedLeague].brand;
 
   const leagues = useMemo(
     () =>
@@ -143,27 +155,64 @@ export function ScoreboardView({ initialLeague = DEFAULT_LEAGUE }: ScoreboardVie
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="inline-flex rounded-full border border-white/10 bg-surface/60 p-1 text-sm shadow-inner backdrop-blur">
+        <div
+          className="inline-flex rounded-full border p-1 text-sm shadow-inner backdrop-blur"
+          style={{
+            borderColor: withOpacity(activeBrand.secondaryColor, 0.25),
+            background: `linear-gradient(120deg, ${withOpacity(
+              activeBrand.surfaceColor,
+              0.85
+            )} 0%, rgba(24, 27, 34, 0.7) 100%)`,
+          }}
+        >
           {leagues.map((league) => {
             const isActive = league.key === selectedLeague;
+            const leagueBrand = LEAGUES[league.key].brand;
+            const headingFont = leagueBrand.typefaces?.heading ?? "font-heading";
+            const activeStyles: CSSProperties = isActive
+              ? {
+                  backgroundColor: leagueBrand.primaryColor,
+                  borderColor: leagueBrand.primaryColor,
+                  color: leagueBrand.onPrimaryColor,
+                  boxShadow: `0 12px 32px -16px ${withOpacity(
+                    leagueBrand.primaryColor,
+                    0.75
+                  )}`,
+                }
+              : {};
+            const inactiveStyles: CSSProperties = !isActive
+              ? {
+                  borderColor: withOpacity(leagueBrand.secondaryColor, 0.35),
+                  color: leagueBrand.secondaryColor,
+                }
+              : {};
             return (
               <button
                 key={league.key}
                 type="button"
                 onClick={() => setSelectedLeague(league.key)}
-                className={`rounded-full px-4 py-2 font-medium transition ${
-                  isActive
-                    ? "bg-accent text-black shadow"
-                    : "text-muted hover:text-white"
-                }`}
+                className={`rounded-full border px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${headingFont}`}
+                style={{
+                  ...inactiveStyles,
+                  ...activeStyles,
+                }}
+                aria-pressed={isActive}
               >
                 {league.label}
               </button>
             );
           })}
         </div>
-        <div className="text-xs text-muted">
-          {isBackgroundRefresh && <span className="mr-2 inline-flex h-2 w-2 animate-ping rounded-full bg-accent" />}
+        <div
+          className="text-xs"
+          style={{ color: withOpacity(activeBrand.mutedColor, 0.85) }}
+        >
+          {isBackgroundRefresh && (
+            <span
+              className="mr-2 inline-flex h-2 w-2 animate-ping rounded-full"
+              style={{ backgroundColor: activeBrand.primaryColor }}
+            />
+          )}
           {data?.games && (
             <span>
               {data.games.length} game{data.games.length === 1 ? "" : "s"} • Updated {lastUpdatedLabel || "just now"}
@@ -197,14 +246,20 @@ export function ScoreboardView({ initialLeague = DEFAULT_LEAGUE }: ScoreboardVie
 
       <div className="grid gap-4 md:grid-cols-2">
         {data?.games?.map((game) => (
-          <GameCard key={game.id} game={game} />
+          <GameCard key={game.id} game={game} leagueKey={selectedLeague} />
         ))}
       </div>
     </div>
   );
 }
 
-function GameCard({ game }: { game: ScoreboardGame }) {
+function GameCard({
+  game,
+  leagueKey,
+}: {
+  game: ScoreboardGame;
+  leagueKey: LeagueKey;
+}) {
   const startDate = useMemo(() => new Date(game.startTime), [game.startTime]);
   const dateLabel = useMemo(() => {
     try {
@@ -229,21 +284,44 @@ function GameCard({ game }: { game: ScoreboardGame }) {
     }
   }, [startDate]);
 
+  const brand = LEAGUES[leagueKey].brand;
+  const headingFont = brand.typefaces?.heading ?? "font-heading";
+  const displayFont = brand.typefaces?.display ?? "font-score";
+  const detailFont = brand.typefaces?.detail ?? "font-sans";
   const statusColor =
     game.status.state === "in"
-      ? "text-accent"
+      ? brand.primaryColor
       : game.status.state === "post"
-      ? "text-white"
-      : "text-muted";
+      ? brand.secondaryColor
+      : brand.mutedColor;
+
+  const cardStyles: CSSProperties = {
+    borderColor: withOpacity(brand.secondaryColor, 0.25),
+    background: `linear-gradient(160deg, ${withOpacity(
+      brand.surfaceColor,
+      0.92
+    )} 0%, rgba(24, 27, 34, 0.88) 70%)`,
+    boxShadow: `0 18px 40px -24px ${withOpacity(brand.primaryColor, 0.55)}`,
+  };
+
+  const headerMutedColor = withOpacity(brand.mutedColor, 0.9);
 
   return (
-    <article className="flex h-full flex-col justify-between rounded-3xl border border-white/5 bg-surface/80 p-6 shadow-card backdrop-blur">
-      <header className="flex items-start justify-between text-sm text-muted">
-        <div>
-          <p className="font-medium text-white">{dateLabel}</p>
-          <p>{timeLabel}</p>
+    <article
+      className="flex h-full flex-col justify-between rounded-3xl border bg-surface/80 p-6 backdrop-blur"
+      style={cardStyles}
+    >
+      <header className="flex items-start justify-between text-xs" style={{ color: headerMutedColor }}>
+        <div className="space-y-0.5">
+          <p className={`${headingFont} text-sm`} style={{ color: brand.onSurfaceColor }}>
+            {dateLabel}
+          </p>
+          <p className={detailFont}>{timeLabel}</p>
         </div>
-        <p className={`text-right text-xs font-semibold uppercase ${statusColor}`}>
+        <p
+          className={`${headingFont} text-right text-[0.65rem] font-semibold uppercase tracking-[0.35em]`}
+          style={{ color: statusColor }}
+        >
           {game.status.shortDetail}
         </p>
       </header>
@@ -253,17 +331,30 @@ function GameCard({ game }: { game: ScoreboardGame }) {
           team={game.away}
           status={game.status.state}
           isHighlighted={determineHighlight(game.away, game.home, game.status.state)}
+          brand={brand}
+          headingFont={headingFont}
+          displayFont={displayFont}
+          detailFont={detailFont}
         />
         <TeamRow
           team={game.home}
           status={game.status.state}
           isHighlighted={determineHighlight(game.home, game.away, game.status.state)}
+          brand={brand}
+          headingFont={headingFont}
+          displayFont={displayFont}
+          detailFont={detailFont}
         />
       </div>
 
-      <footer className="mt-6 flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
+      <footer
+        className={`mt-6 flex flex-wrap items-center justify-between gap-2 text-xs ${detailFont}`}
+        style={{ color: withOpacity(brand.mutedColor, 0.75) }}
+      >
         <span>{game.venue ?? "Venue TBA"}</span>
-        {game.broadcast && <span className="text-accent-200">{game.broadcast}</span>}
+        {game.broadcast && (
+          <span style={{ color: brand.secondaryColor }}>{game.broadcast}</span>
+        )}
       </footer>
     </article>
   );
@@ -289,32 +380,101 @@ function TeamRow({
   team,
   status,
   isHighlighted,
+  brand,
+  headingFont,
+  displayFont,
+  detailFont,
 }: {
   team: TeamScore;
   status: "pre" | "in" | "post";
   isHighlighted: boolean;
+  brand: LeagueBrand;
+  headingFont: string;
+  displayFont: string;
+  detailFont: string;
 }) {
   const displayScore = team.score !== null ? team.score : "--";
   const locationLabel = team.homeAway === "home" ? "Home" : "Away";
 
+  const containerStyles: CSSProperties = {
+    backgroundColor: isHighlighted
+      ? brand.primaryColor
+      : withOpacity(brand.surfaceColor, 0.9),
+    borderColor: withOpacity(
+      isHighlighted ? brand.primaryColor : brand.secondaryColor,
+      isHighlighted ? 0.75 : 0.45
+    ),
+    color: isHighlighted ? brand.onPrimaryColor : brand.onSurfaceColor,
+    boxShadow: isHighlighted
+      ? `0 14px 30px -18px ${withOpacity(brand.primaryColor, 0.65)}`
+      : undefined,
+  };
+
+  const metaColor = isHighlighted
+    ? withOpacity(brand.onPrimaryColor, 0.75)
+    : withOpacity(brand.mutedColor, 0.9);
+
+  const recordColor = isHighlighted
+    ? withOpacity(brand.onPrimaryColor, 0.65)
+    : withOpacity(brand.mutedColor, 0.75);
+
+  const scoreStyles: CSSProperties = isHighlighted
+    ? {
+        backgroundColor: brand.onPrimaryColor,
+        borderColor: brand.onPrimaryColor,
+        color: brand.primaryColor,
+      }
+    : {
+        backgroundColor:
+          status === "post"
+            ? withOpacity(brand.secondaryColor, 0.18)
+            : withOpacity(brand.secondaryColor, 0.12),
+        borderColor: withOpacity(brand.secondaryColor, 0.45),
+        color: brand.onSurfaceColor,
+      };
+
   return (
-    <div className="flex items-center justify-between gap-4 rounded-2xl bg-black/20 px-4 py-3">
+    <div
+      className="flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 transition"
+      style={containerStyles}
+    >
       <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-[0.4em] text-muted">{locationLabel}</span>
-        <span className="text-lg font-semibold text-white">{team.displayName}</span>
-        {team.record && <span className="text-xs text-muted">{team.record}</span>}
+        <span
+          className={`${detailFont} text-[0.65rem] uppercase tracking-[0.35em]`}
+          style={{ color: metaColor }}
+        >
+          {locationLabel}
+        </span>
+        <span className={`${headingFont} text-xl font-semibold`}>{team.displayName}</span>
+        {team.record && (
+          <span className={`${detailFont} text-xs`} style={{ color: recordColor }}>
+            {team.record}
+          </span>
+        )}
       </div>
       <div
-        className={`flex h-12 w-12 items-center justify-center rounded-xl border border-white/10 text-xl font-bold transition ${
-          isHighlighted
-            ? "bg-accent text-black"
-            : status === "post"
-            ? "bg-white/10 text-white"
-            : "bg-black/40 text-white"
-        }`}
+        className={`${displayFont} flex h-14 w-14 items-center justify-center rounded-xl border text-2xl font-semibold transition`}
+        style={scoreStyles}
       >
         {displayScore}
       </div>
     </div>
   );
+}
+
+function withOpacity(hexColor: string, opacity: number): string {
+  const normalized = hexColor.replace("#", "").trim();
+
+  if (normalized.length !== 6) {
+    return hexColor;
+  }
+
+  const numeric = Number.parseInt(normalized, 16);
+  const r = (numeric >> 16) & 255;
+  const g = (numeric >> 8) & 255;
+  const b = numeric & 255;
+
+  const clamped = Math.min(1, Math.max(0, opacity));
+
+  return `rgba(${r}, ${g}, ${b}, ${clamped.toFixed(3)})`;
 }

--- a/lib/leagues.ts
+++ b/lib/leagues.ts
@@ -1,3 +1,27 @@
+export interface LeagueTypefaces {
+  heading?: string;
+  display?: string;
+  detail?: string;
+}
+
+export interface LeagueBrand {
+  primaryColor: string;
+  secondaryColor: string;
+  surfaceColor: string;
+  onPrimaryColor: string;
+  onSurfaceColor: string;
+  mutedColor: string;
+  typefaces?: LeagueTypefaces;
+}
+
+export interface LeagueConfig {
+  key: string;
+  label: string;
+  sport: string;
+  scoreboardUrl: string;
+  brand: LeagueBrand;
+}
+
 export const LEAGUES = {
   wnba: {
     key: "wnba",
@@ -5,6 +29,19 @@ export const LEAGUES = {
     sport: "Basketball",
     scoreboardUrl:
       "https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/scoreboard",
+    brand: {
+      primaryColor: "#f37021",
+      secondaryColor: "#fdba74",
+      surfaceColor: "#241a13",
+      onPrimaryColor: "#0b0b0b",
+      onSurfaceColor: "#fdf4ed",
+      mutedColor: "#f4b98a",
+      typefaces: {
+        heading: "font-heading",
+        display: "font-score",
+        detail: "font-sans",
+      },
+    },
   },
   nwsl: {
     key: "nwsl",
@@ -12,6 +49,19 @@ export const LEAGUES = {
     sport: "Soccer",
     scoreboardUrl:
       "https://site.api.espn.com/apis/site/v2/sports/soccer/usa.nwsl/scoreboard",
+    brand: {
+      primaryColor: "#002d72",
+      secondaryColor: "#7ea6e0",
+      surfaceColor: "#111927",
+      onPrimaryColor: "#f9fafb",
+      onSurfaceColor: "#e2e8f0",
+      mutedColor: "#94a3b8",
+      typefaces: {
+        heading: "font-heading",
+        display: "font-score",
+        detail: "font-sans",
+      },
+    },
   },
   pwhl: {
     key: "pwhl",
@@ -19,8 +69,21 @@ export const LEAGUES = {
     sport: "Hockey",
     scoreboardUrl:
       "https://site.api.espn.com/apis/site/v2/sports/hockey/pwhl/scoreboard",
+    brand: {
+      primaryColor: "#00b5e2",
+      secondaryColor: "#7fe3ff",
+      surfaceColor: "#10242a",
+      onPrimaryColor: "#04111b",
+      onSurfaceColor: "#e6fbff",
+      mutedColor: "#9ad9e8",
+      typefaces: {
+        heading: "font-heading",
+        display: "font-score",
+        detail: "font-sans",
+      },
+    },
   },
-} as const;
+} satisfies Record<string, LeagueConfig>;
 
 export type LeagueKey = keyof typeof LEAGUES;
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,7 +27,20 @@ const config: Config = {
         muted: "#6b7280"
       },
       fontFamily: {
-        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        heading: [
+          "var(--font-heading)",
+          "var(--font-sans)",
+          "system-ui",
+          "sans-serif",
+        ],
+        score: [
+          "var(--font-score)",
+          "var(--font-heading)",
+          "var(--font-sans)",
+          "system-ui",
+          "sans-serif",
+        ],
       },
       boxShadow: {
         card: "0 18px 40px -24px rgba(168, 85, 247, 0.45)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,12 +18,30 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add league branding metadata including colors and typefaces
- restyle the scoreboard toggle and game cards to use per-league palettes and typography
- load new Google fonts and expose tailwind font families for headings and scores

## Testing
- pnpm lint *(fails: Failed to load config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68dd83a0f088832e9eaeb0e853f08b42