### PR TITLE
Add news feed and personalization panels

### DIFF
--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface FavoriteItem {
+  id: string;
+  label: string;
+  category: "team" | "league";
+}
+
+const COOKIE_NAME = "rtg-favorites";
+
+function readFavorites(request: NextRequest): FavoriteItem[] {
+  const cookie = request.cookies.get(COOKIE_NAME)?.value;
+
+  if (!cookie) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(cookie);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (item): item is FavoriteItem =>
+        typeof item?.id === "string" &&
+        typeof item?.label === "string" &&
+        (item?.category === "team" || item?.category === "league")
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeFavorites(favorites: FavoriteItem[]) {
+  return {
+    name: COOKIE_NAME,
+    value: JSON.stringify(favorites),
+    httpOnly: false,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const favorites = readFavorites(request);
+
+  return NextResponse.json({ favorites });
+}
+
+export async function POST(request: NextRequest) {
+  const favorites = readFavorites(request);
+
+  try {
+    const payload = (await request.json()) as Partial<FavoriteItem>;
+    const { id, label, category } = payload;
+
+    if (!id || !label || (category !== "team" && category !== "league")) {
+      return NextResponse.json(
+        { error: "Favorites must include an id, label, and category." },
+        { status: 400 }
+      );
+    }
+
+    const exists = favorites.some((item) => item.id === id);
+
+    if (exists) {
+      const response = NextResponse.json({ favorites });
+      response.cookies.set(writeFavorites(favorites));
+      return response;
+    }
+
+    const updated = [...favorites, { id, label, category }];
+    const response = NextResponse.json({ favorites: updated });
+    response.cookies.set(writeFavorites(updated));
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to save favorite right now.",
+      },
+      { status: 400 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const favorites = readFavorites(request);
+
+  try {
+    const payload = (await request.json()) as Partial<FavoriteItem>;
+    const { id } = payload;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "Favorite id is required for deletion." },
+        { status: 400 }
+      );
+    }
+
+    const updated = favorites.filter((item) => item.id !== id);
+    const response = NextResponse.json({ favorites: updated });
+    response.cookies.set(writeFavorites(updated));
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to remove favorite right now.",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+const MOCK_NEWS = [
+  {
+    id: "wnba-2024-finals-preview",
+    title: "Five storylines to watch heading into the WNBA Finals",
+    summary:
+      "A closer look at the key matchups, player rivalries, and tactical wrinkles that will define this year's championship series.",
+    league: "wnba",
+    publishedAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+    author: "Alex Morgan",
+    url: "https://example.com/wnba-finals-preview",
+  },
+  {
+    id: "nwsl-rivalry-week",
+    title: "NWSL Rivalry Week delivers drama from coast to coast",
+    summary:
+      "Late winners, stunning saves, and playoff implications — we break down the biggest moments from the weekend slate.",
+    league: "nwsl",
+    publishedAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+    author: "Jordan Martinez",
+    url: "https://example.com/nwsl-rivalry-week",
+  },
+  {
+    id: "pwhl-draft-class-spotlight",
+    title: "Meet the rising stars from this season's PWHL draft class",
+    summary:
+      "From blistering slapshots to poised two-way centers, the next wave of PWHL talent is already making an impact.",
+    league: "pwhl",
+    publishedAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+    author: "Taylor Chen",
+    url: "https://example.com/pwhl-draft-class",
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({
+    articles: MOCK_NEWS,
+    refreshInterval: 300,
+  });
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface NotificationPreferences {
+  gameStart: boolean;
+  finalScore: boolean;
+  breakingNews: boolean;
+  email?: string | null;
+}
+
+const COOKIE_NAME = "rtg-notification-preferences";
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  gameStart: true,
+  finalScore: true,
+  breakingNews: false,
+  email: null,
+};
+
+function readPreferences(request: NextRequest): NotificationPreferences {
+  const cookie = request.cookies.get(COOKIE_NAME)?.value;
+
+  if (!cookie) {
+    return DEFAULT_PREFERENCES;
+  }
+
+  try {
+    const parsed = JSON.parse(cookie);
+
+    if (typeof parsed !== "object" || parsed === null) {
+      return DEFAULT_PREFERENCES;
+    }
+
+    return {
+      gameStart: Boolean(parsed.gameStart),
+      finalScore: Boolean(parsed.finalScore),
+      breakingNews: Boolean(parsed.breakingNews),
+      email:
+        typeof parsed.email === "string" && parsed.email.length > 0
+          ? parsed.email
+          : null,
+    };
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+function writePreferences(preferences: NotificationPreferences) {
+  return {
+    name: COOKIE_NAME,
+    value: JSON.stringify(preferences),
+    httpOnly: false,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const preferences = readPreferences(request);
+  return NextResponse.json({ preferences });
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const payload = (await request.json()) as Partial<NotificationPreferences>;
+
+    const preferences: NotificationPreferences = {
+      gameStart:
+        typeof payload.gameStart === "boolean"
+          ? payload.gameStart
+          : DEFAULT_PREFERENCES.gameStart,
+      finalScore:
+        typeof payload.finalScore === "boolean"
+          ? payload.finalScore
+          : DEFAULT_PREFERENCES.finalScore,
+      breakingNews:
+        typeof payload.breakingNews === "boolean"
+          ? payload.breakingNews
+          : DEFAULT_PREFERENCES.breakingNews,
+      email:
+        typeof payload.email === "string" && payload.email.length > 0
+          ? payload.email
+          : null,
+    };
+
+    const response = NextResponse.json({ preferences });
+    response.cookies.set(writePreferences(preferences));
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to update notification preferences right now.",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
 import { DEFAULT_LEAGUE } from "@/lib/leagues";
+import { FavoritesBar } from "@/components/favorites-bar";
+import { NewsPanel } from "@/components/news-panel";
 import { ScoreboardView } from "@/components/scoreboard-view";
+import { NotificationPreferencesPanel } from "@/components/notification-preferences";
 
 export default function HomePage() {
   return (
@@ -18,9 +21,18 @@ export default function HomePage() {
           </p>
         </header>
 
-        <section className="flex-1">
-          <ScoreboardView initialLeague={DEFAULT_LEAGUE} />
-        </section>
+        <div className="flex-1 space-y-10">
+          <div className="grid gap-10 lg:grid-cols-[1.75fr_1fr]">
+            <section className="space-y-8">
+              <ScoreboardView initialLeague={DEFAULT_LEAGUE} />
+              <FavoritesBar />
+              <NotificationPreferencesPanel />
+            </section>
+            <aside>
+              <NewsPanel />
+            </aside>
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/components/favorites-bar.tsx
+++ b/components/favorites-bar.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { FavoriteItem, useFavorites } from "@/lib/hooks/use-favorites";
+
+const DEFAULT_CATEGORIES: Array<{ label: string; value: FavoriteItem["category"] }> = [
+  { label: "Team", value: "team" },
+  { label: "League", value: "league" },
+];
+
+export function FavoritesBar() {
+  const { favorites, loading, error, saving, addFavorite, removeFavorite } = useFavorites();
+  const [name, setName] = useState<string>("");
+  const [category, setCategory] = useState<FavoriteItem["category"]>("team");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const isSubmitDisabled = useMemo(() => {
+    return saving || name.trim().length === 0;
+  }, [saving, name]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmed = name.trim();
+
+    if (!trimmed) {
+      setFormError("Please enter a name to save to favorites.");
+      return;
+    }
+
+    const id = `${category}-${trimmed.toLowerCase().replace(/\s+/g, "-")}`;
+
+    const favorite: FavoriteItem = {
+      id,
+      label: trimmed,
+      category,
+    };
+
+    const success = await addFavorite(favorite);
+    if (success) {
+      setName("");
+      setFormError(null);
+    }
+  }
+
+  const hasFavorites = favorites.length > 0;
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/5 bg-surface/60 p-6 backdrop-blur">
+      <header className="space-y-1">
+        <p className="text-xs uppercase tracking-[0.35em] text-muted">Your Hub</p>
+        <h2 className="text-xl font-semibold text-white">Favorites</h2>
+        <p className="text-sm text-muted">
+          Pin the teams and leagues you care about most to tailor the scoreboard.
+        </p>
+      </header>
+
+      {(error || formError) && (
+        <div className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          {formError ?? error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <span
+              key={index}
+              className="inline-flex h-9 w-24 animate-pulse items-center justify-center rounded-full border border-white/5 bg-white/10"
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && !hasFavorites && !error && (
+        <p className="rounded-2xl border border-white/5 bg-surface/80 px-4 py-3 text-sm text-muted">
+          You haven&apos;t saved any favorites yet. Add a team or league to get started.
+        </p>
+      )}
+
+      {hasFavorites && (
+        <ul className="flex flex-wrap gap-2">
+          {favorites.map((favorite) => (
+            <li key={favorite.id}>
+              <button
+                type="button"
+                onClick={() => removeFavorite(favorite.id)}
+                className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-white transition hover:border-accent-200/60 hover:bg-accent-500/10"
+                title="Remove favorite"
+              >
+                <span className="rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.3em] text-muted">
+                  {favorite.category}
+                </span>
+                <span>{favorite.label}</span>
+                <span className="text-muted transition group-hover:text-accent-200">×</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form className="mt-4 space-y-3" onSubmit={handleSubmit}>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <label className="flex-1 text-sm text-white">
+            <span className="mb-1 block text-xs uppercase tracking-[0.35em] text-muted">Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Seattle Storm"
+              className="w-full rounded-xl border border-white/5 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-muted focus:border-accent-200 focus:outline-none focus:ring-2 focus:ring-accent-500/40"
+            />
+          </label>
+          <label className="text-sm text-white">
+            <span className="mb-1 block text-xs uppercase tracking-[0.35em] text-muted">Category</span>
+            <select
+              value={category}
+              onChange={(event) => setCategory(event.target.value as FavoriteItem["category"])}
+              className="w-full rounded-xl border border-white/5 bg-black/40 px-3 py-2 text-sm text-white focus:border-accent-200 focus:outline-none focus:ring-2 focus:ring-accent-500/40"
+            >
+              {DEFAULT_CATEGORIES.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-full border border-accent-200/60 bg-accent-500/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSubmitDisabled}
+        >
+          {saving ? "Saving..." : "Add to favorites"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/components/news-panel.tsx
+++ b/components/news-panel.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+interface NewsArticle {
+  id: string;
+  title: string;
+  summary: string;
+  league: string;
+  publishedAt: string;
+  author: string;
+  url: string;
+}
+
+interface NewsResponse {
+  articles: NewsArticle[];
+  refreshInterval: number;
+}
+
+export function NewsPanel() {
+  const [articles, setArticles] = useState<NewsArticle[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshInterval, setRefreshInterval] = useState<number | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const controller = new AbortController();
+
+    async function loadNews(options: { background?: boolean } = {}) {
+      const { background = false } = options;
+
+      if (!background) {
+        setLoading(true);
+        setError(null);
+      }
+
+      try {
+        const response = await fetch("/api/news", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`News request failed: ${response.status}`);
+        }
+
+        const payload: NewsResponse = await response.json();
+
+        if (!mounted) {
+          return;
+        }
+
+        setArticles(Array.isArray(payload.articles) ? payload.articles : []);
+        setRefreshInterval(payload.refreshInterval ?? null);
+        setError(null);
+      } catch (err) {
+        if (!mounted || (err as Error).name === "AbortError") {
+          return;
+        }
+
+        setError("Unable to load the latest headlines. Please try again soon.");
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadNews().catch(() => {
+      // handled in loadNews
+    });
+
+    return () => {
+      mounted = false;
+      controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!refreshInterval || refreshInterval <= 0) {
+      return;
+    }
+
+    const id = window.setInterval(() => {
+      loadLatest().catch(() => {
+        // handled in loadLatest
+      });
+    }, refreshInterval * 1000);
+
+    async function loadLatest() {
+      try {
+        const response = await fetch("/api/news", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`News refresh failed: ${response.status}`);
+        }
+
+        const payload: NewsResponse = await response.json();
+        setArticles(Array.isArray(payload.articles) ? payload.articles : []);
+        setRefreshInterval(payload.refreshInterval ?? refreshInterval);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    return () => window.clearInterval(id);
+  }, [refreshInterval]);
+
+  const groupedArticles = useMemo(() => {
+    return articles.reduce<Record<string, NewsArticle[]>>((acc, article) => {
+      const key = article.league.toUpperCase();
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(article);
+      return acc;
+    }, {});
+  }, [articles]);
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-baseline justify-between">
+        <h2 className="text-xl font-semibold">Latest Headlines</h2>
+        <span className="text-xs uppercase tracking-[0.35em] text-muted">News Desk</span>
+      </header>
+
+      {error && (
+        <div className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="animate-pulse rounded-2xl border border-white/5 bg-surface/40 px-4 py-5"
+            >
+              <div className="h-3 w-24 rounded bg-white/10" />
+              <div className="mt-3 h-4 w-3/4 rounded bg-white/10" />
+              <div className="mt-2 h-4 w-2/3 rounded bg-white/5" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && articles.length === 0 && !error && (
+        <div className="rounded-2xl border border-white/5 bg-surface/60 px-6 py-10 text-center text-sm text-muted">
+          No headlines to share just yet. Check back soon for fresh coverage.
+        </div>
+      )}
+
+      {!loading && articles.length > 0 && (
+        <div className="space-y-6">
+          {Object.entries(groupedArticles).map(([league, leagueArticles]) => (
+            <div key={league} className="space-y-3">
+              <h3 className="text-xs uppercase tracking-[0.35em] text-muted">{league}</h3>
+              <ul className="space-y-3">
+                {leagueArticles.map((article) => (
+                  <li key={article.id} className="rounded-2xl border border-white/5 bg-surface/80 p-5">
+                    <article className="space-y-2">
+                      <div className="flex items-start justify-between gap-4 text-xs text-muted">
+                        <span>{formatRelativeTime(article.publishedAt)}</span>
+                        <span>{article.author}</span>
+                      </div>
+                      <a
+                        href={article.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-lg font-semibold text-white transition hover:text-accent-200"
+                      >
+                        {article.title}
+                      </a>
+                      <p className="text-sm text-muted">{article.summary}</p>
+                    </article>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatRelativeTime(timestamp: string) {
+  try {
+    const date = new Date(timestamp);
+    const diff = Date.now() - date.getTime();
+    const minutes = Math.round(diff / (1000 * 60));
+
+    if (Number.isNaN(minutes)) {
+      throw new Error("Invalid date");
+    }
+
+    if (minutes < 1) {
+      return "Just now";
+    }
+
+    if (minutes < 60) {
+      return `${minutes} min ago`;
+    }
+
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) {
+      return `${hours} hr${hours > 1 ? "s" : ""} ago`;
+    }
+
+    const days = Math.round(hours / 24);
+    return `${days} day${days > 1 ? "s" : ""} ago`;
+  } catch {
+    return "Recently";
+  }
+}

--- a/components/notification-preferences.tsx
+++ b/components/notification-preferences.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import {
+  NotificationPreferences,
+  useNotificationPreferences,
+} from "@/lib/hooks/use-notification-preferences";
+
+export function NotificationPreferencesPanel() {
+  const { preferences, loading, error, saving, updatePreferences } =
+    useNotificationPreferences();
+  const [formState, setFormState] = useState<NotificationPreferences>(preferences);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFormState(preferences);
+  }, [preferences]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFormError(null);
+    setFormSuccess(null);
+
+    if (formState.email && !isValidEmail(formState.email)) {
+      setFormError("Please provide a valid email address.");
+      return;
+    }
+
+    const success = await updatePreferences(formState);
+
+    if (success) {
+      setFormSuccess("Preferences saved.");
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/5 bg-surface/60 p-6 backdrop-blur">
+      <header className="space-y-1">
+        <p className="text-xs uppercase tracking-[0.35em] text-muted">Stay Informed</p>
+        <h2 className="text-xl font-semibold text-white">Notifications</h2>
+        <p className="text-sm text-muted">
+          Choose how we keep you updated on game action and breaking news.
+        </p>
+      </header>
+
+      {(error || formError || formSuccess) && (
+        <div
+          className={`rounded-xl border px-4 py-3 text-sm ${
+            formError
+              ? "border-red-400/30 bg-red-500/10 text-red-100"
+              : formSuccess
+              ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-100"
+              : "border-amber-400/30 bg-amber-500/10 text-amber-100"
+          }`}
+        >
+          {formError ?? formSuccess ?? error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-3">
+              <span className="h-5 w-5 rounded border border-white/10 bg-white/10" />
+              <span className="h-4 w-40 rounded bg-white/10" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <fieldset className="space-y-3">
+            <legend className="text-xs uppercase tracking-[0.35em] text-muted">
+              Alerts
+            </legend>
+            <ToggleRow
+              id="game-start"
+              label="Game start"
+              description="Ping me when my teams are about to tip off, kick off, or drop the puck."
+              checked={formState.gameStart}
+              onChange={(checked) =>
+                setFormState((current) => ({ ...current, gameStart: checked }))
+              }
+            />
+            <ToggleRow
+              id="final-score"
+              label="Final score"
+              description="Send the final score and top performers when the action wraps."
+              checked={formState.finalScore}
+              onChange={(checked) =>
+                setFormState((current) => ({ ...current, finalScore: checked }))
+              }
+            />
+            <ToggleRow
+              id="breaking-news"
+              label="Breaking news"
+              description="Get notified when major trades, injuries, or signings hit the wire."
+              checked={formState.breakingNews}
+              onChange={(checked) =>
+                setFormState((current) => ({ ...current, breakingNews: checked }))
+              }
+            />
+          </fieldset>
+
+          <div className="space-y-2">
+            <label className="block text-sm text-white">
+              <span className="mb-1 block text-xs uppercase tracking-[0.35em] text-muted">
+                Email address (optional)
+              </span>
+              <input
+                type="email"
+                value={formState.email ?? ""}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, email: event.target.value || null }))
+                }
+                placeholder="you@example.com"
+                className="w-full rounded-xl border border-white/5 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-muted focus:border-accent-200 focus:outline-none focus:ring-2 focus:ring-accent-500/40"
+              />
+            </label>
+            <p className="text-xs text-muted">
+              We&apos;ll use your email to send only the updates you opt into.
+            </p>
+          </div>
+
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full border border-accent-200/60 bg-accent-500/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save preferences"}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function ToggleRow({
+  id,
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label htmlFor={id} className="flex items-start justify-between gap-4 rounded-2xl border border-white/5 bg-black/40 px-4 py-3">
+      <span>
+        <span className="block text-sm font-medium text-white">{label}</span>
+        <span className="block text-xs text-muted">{description}</span>
+      </span>
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-1 h-5 w-5 rounded border border-white/10 bg-white/10 text-accent-200 focus:ring-accent-200"
+      />
+    </label>
+  );
+}
+
+function isValidEmail(email: string) {
+  return /.+@.+\..+/.test(email);
+}

--- a/lib/client-storage.ts
+++ b/lib/client-storage.ts
@@ -1,0 +1,41 @@
+export function getStoredValue<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key);
+
+    if (!raw) {
+      return fallback;
+    }
+
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function setStoredValue<T>(key: string, value: T) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // localStorage may be unavailable (private mode, storage disabled, etc.)
+  }
+}
+
+export function removeStoredValue(key: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore failures clearing storage.
+  }
+}

--- a/lib/hooks/use-favorites.ts
+++ b/lib/hooks/use-favorites.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getStoredValue, setStoredValue } from "@/lib/client-storage";
+
+export interface FavoriteItem {
+  id: string;
+  label: string;
+  category: "team" | "league";
+}
+
+const STORAGE_KEY = "rtg:favorites";
+
+interface UseFavoritesResult {
+  favorites: FavoriteItem[];
+  loading: boolean;
+  error: string | null;
+  saving: boolean;
+  addFavorite: (favorite: FavoriteItem) => Promise<boolean>;
+  removeFavorite: (id: string) => Promise<boolean>;
+}
+
+export function useFavorites(): UseFavoritesResult {
+  const [favorites, setFavorites] = useState<FavoriteItem[]>(() =>
+    getStoredValue(STORAGE_KEY, [])
+  );
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadFavorites() {
+      try {
+        const response = await fetch("/api/favorites", { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(`Favorites request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+
+        if (!mounted) {
+          return;
+        }
+
+        const items = Array.isArray(payload.favorites) ? payload.favorites : [];
+        setFavorites(items);
+        setStoredValue(STORAGE_KEY, items);
+        setError(null);
+      } catch {
+        if (mounted) {
+          setError("We couldn't load your favorites just yet.");
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadFavorites().catch(() => {
+      // handled in loadFavorites
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setStoredValue(STORAGE_KEY, favorites);
+  }, [favorites]);
+
+  const addFavorite = useCallback(async (favorite: FavoriteItem) => {
+    setSaving(true);
+    try {
+      const response = await fetch("/api/favorites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(favorite),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unable to add favorite: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const items = Array.isArray(payload.favorites) ? payload.favorites : [];
+      setFavorites(items);
+      setError(null);
+      return true;
+    } catch (error) {
+      console.error(error);
+      setError("We couldn't save that favorite. Please try again.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const removeFavorite = useCallback(async (id: string) => {
+    setSaving(true);
+    try {
+      const response = await fetch("/api/favorites", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unable to remove favorite: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const items = Array.isArray(payload.favorites) ? payload.favorites : [];
+      setFavorites(items);
+      setError(null);
+      return true;
+    } catch (error) {
+      console.error(error);
+      setError("We couldn't remove that favorite right now.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  return useMemo(
+    () => ({ favorites, loading, error, saving, addFavorite, removeFavorite }),
+    [favorites, loading, error, saving, addFavorite, removeFavorite]
+  );
+}

--- a/lib/hooks/use-notification-preferences.ts
+++ b/lib/hooks/use-notification-preferences.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getStoredValue, setStoredValue } from "@/lib/client-storage";
+
+export interface NotificationPreferences {
+  gameStart: boolean;
+  finalScore: boolean;
+  breakingNews: boolean;
+  email: string | null;
+}
+
+const STORAGE_KEY = "rtg:notification-preferences";
+
+interface UseNotificationPreferencesResult {
+  preferences: NotificationPreferences;
+  loading: boolean;
+  error: string | null;
+  saving: boolean;
+  updatePreferences: (update: NotificationPreferences) => Promise<boolean>;
+}
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  gameStart: true,
+  finalScore: true,
+  breakingNews: false,
+  email: null,
+};
+
+export function useNotificationPreferences(): UseNotificationPreferencesResult {
+  const [preferences, setPreferences] = useState<NotificationPreferences>(() =>
+    getStoredValue(STORAGE_KEY, DEFAULT_PREFERENCES)
+  );
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadPreferences() {
+      try {
+        const response = await fetch("/api/notifications", { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(`Notification request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const nextPreferences: NotificationPreferences = {
+          ...DEFAULT_PREFERENCES,
+          ...(payload?.preferences ?? {}),
+        };
+
+        if (mounted) {
+          setPreferences(nextPreferences);
+          setStoredValue(STORAGE_KEY, nextPreferences);
+          setError(null);
+        }
+      } catch {
+        if (mounted) {
+          setError("We couldn't load your notification settings just yet.");
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadPreferences().catch(() => {
+      // handled in loadPreferences
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setStoredValue(STORAGE_KEY, preferences);
+  }, [preferences]);
+
+  const updatePreferences = useCallback(async (update: NotificationPreferences) => {
+    setSaving(true);
+    try {
+      const response = await fetch("/api/notifications", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unable to update preferences: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const nextPreferences: NotificationPreferences = {
+        ...DEFAULT_PREFERENCES,
+        ...(payload?.preferences ?? {}),
+      };
+
+      setPreferences(nextPreferences);
+      setError(null);
+      return true;
+    } catch (error) {
+      console.error(error);
+      setError("We couldn't update your notifications right now.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  return useMemo(
+    () => ({ preferences, loading, error, saving, updatePreferences }),
+    [preferences, loading, error, saving, updatePreferences]
+  );
+}


### PR DESCRIPTION
## Summary
- add a mock league news API and a news panel component to surface the latest headlines
- implement favorites and notification preference APIs backed by cookies plus client hooks that persist to localStorage
- restructure the homepage layout to showcase news, favorites, and notification controls alongside the scoreboard

## Testing
- pnpm lint *(fails: Failed to load config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68dd874d8440832e82ee5c1900330c9a