### PR TITLE
Handle missing ESPN scoreboard data gracefully

### DIFF
--- a/app/api/scoreboard/route.ts
+++ b/app/api/scoreboard/route.ts
@@ -27,6 +27,23 @@ export async function GET(request: NextRequest) {
     });
 
     if (!response.ok) {
+      if ([204, 404].includes(response.status)) {
+        const payload = mapEspnScoreboard({ events: [] }, leagueKey);
+        const notice =
+          response.status === 204
+            ? "ESPN hasn't published scoreboard data for this league yet today."
+            : "ESPN's scoreboard feed for this league isn't available right now. We'll keep checking for updates.";
+
+        return Response.json(
+          { ...payload, notice },
+          {
+            headers: {
+              "Cache-Control": `public, s-maxage=${payload.refreshInterval}, stale-while-revalidate=60`,
+            },
+          }
+        );
+      }
+
       return Response.json(
         { error: ERROR_MESSAGE, status: response.status },
         { status: 502 }

--- a/components/scoreboard-view.tsx
+++ b/components/scoreboard-view.tsx
@@ -20,6 +20,7 @@ interface ScoreboardResponse {
   games: ScoreboardGame[];
   lastUpdated: string;
   refreshInterval: number;
+  notice?: string;
 }
 
 interface ScoreboardGame {
@@ -239,8 +240,13 @@ export function ScoreboardView({ initialLeague = DEFAULT_LEAGUE }: ScoreboardVie
       )}
 
       {!loading && data?.games?.length === 0 && !error && (
-        <div className="rounded-2xl border border-white/5 bg-surface/60 px-6 py-10 text-center text-sm text-muted">
-          We don&apos;t see any scheduled or live games for {LEAGUES[selectedLeague].label} today.
+        <div className="space-y-3">
+          {data.notice && (
+            <p className="text-center text-sm text-muted">{data.notice}</p>
+          )}
+          <div className="rounded-2xl border border-white/5 bg-surface/60 px-6 py-10 text-center text-sm text-muted">
+            We don&apos;t see any scheduled or live games for {LEAGUES[selectedLeague].label} today.
+          </div>
         </div>
       )}
 

--- a/tests/app/api/scoreboard-route.test.ts
+++ b/tests/app/api/scoreboard-route.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GET } from "@/app/api/scoreboard/route";
+
+const ORIGINAL_FETCH = global.fetch;
+
+test("scoreboard route returns empty results for ESPN 404", async () => {
+  global.fetch = async () =>
+    new Response(null, { status: 404, statusText: "Not Found" });
+
+  try {
+    const request = { url: "http://localhost/api/scoreboard?league=wnba" } as any;
+    const response = await GET(request);
+
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(Array.isArray(payload.games), true);
+    assert.equal(payload.games.length, 0);
+  } finally {
+    global.fetch = ORIGINAL_FETCH;
+  }
+});


### PR DESCRIPTION
## Summary
- treat ESPN 404/204 responses from the ESPN feed as empty scoreboard payloads with a user-facing notice
- surface optional notices in the scoreboard view when no games are returned
- add a unit test covering the 404 response handling in the scoreboard route

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9041e768832e926d03129063080b