### PR TITLE
Add ESPN news normalization and API integration

### DIFF
--- a/components/news-panel.tsx
+++ b/components/news-panel.tsx
@@ -2,23 +2,15 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-interface NewsArticle {
-  id: string;
-  title: string;
-  summary: string;
-  league: string;
-  publishedAt: string;
-  author: string;
-  url: string;
-}
+import type { NormalizedNewsArticle } from "@/lib/news";
 
 interface NewsResponse {
-  articles: NewsArticle[];
+  articles: NormalizedNewsArticle[];
   refreshInterval: number;
 }
 
 export function NewsPanel() {
-  const [articles, setArticles] = useState<NewsArticle[]>([]);
+  const [articles, setArticles] = useState<NormalizedNewsArticle[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshInterval, setRefreshInterval] = useState<number | null>(null);
@@ -107,7 +99,7 @@ export function NewsPanel() {
   }, [refreshInterval]);
 
   const groupedArticles = useMemo(() => {
-    return articles.reduce<Record<string, NewsArticle[]>>((acc, article) => {
+    return articles.reduce<Record<string, NormalizedNewsArticle[]>>((acc, article) => {
       const key = article.league.toUpperCase();
       if (!acc[key]) {
         acc[key] = [];
@@ -162,7 +154,7 @@ export function NewsPanel() {
                     <article className="space-y-2">
                       <div className="flex items-start justify-between gap-4 text-xs text-muted">
                         <span>{formatRelativeTime(article.publishedAt)}</span>
-                        <span>{article.author}</span>
+                        {article.author ? <span>{article.author}</span> : null}
                       </div>
                       <a
                         href={article.url}

--- a/lib/news.ts
+++ b/lib/news.ts
@@ -1,0 +1,152 @@
+export type SupportedLeague = "wnba" | "nwsl" | "pwhl";
+
+export interface NormalizedNewsArticle {
+  id: string;
+  title: string;
+  summary: string;
+  league: SupportedLeague;
+  publishedAt: string;
+  author?: string;
+  url: string;
+}
+
+interface EspnLink {
+  href?: string;
+}
+
+interface EspnArticle {
+  id?: string | number;
+  guid?: string;
+  headline?: string;
+  title?: string;
+  name?: string;
+  description?: string;
+  summary?: string;
+  subtitle?: string;
+  shortHeadline?: string;
+  byline?: string;
+  published?: string;
+  publishedAt?: string;
+  lastModified?: string;
+  updated?: string;
+  created?: string;
+  displayDate?: string;
+  link?: string;
+  href?: string;
+  links?: {
+    web?: EspnLink;
+    mobile?: EspnLink;
+  };
+}
+
+interface EspnNewsPayload {
+  articles?: EspnArticle[];
+  headlines?: EspnArticle[];
+}
+
+const DEFAULT_PUBLISHED_AT = () => new Date().toISOString();
+
+const LEAGUE_ENDPOINTS: Record<SupportedLeague, string> = {
+  wnba: "https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/news",
+  nwsl: "https://site.api.espn.com/apis/site/v2/sports/soccer/usa.nwsl/news",
+  pwhl: "https://site.api.espn.com/apis/site/v2/sports/hockey/pwhl/news",
+};
+
+function parseDate(value?: string): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return DEFAULT_PUBLISHED_AT();
+}
+
+function extractUrl(article: EspnArticle): string | null {
+  const candidates = [
+    article.links?.web?.href,
+    article.links?.mobile?.href,
+    article.link,
+    article.href,
+  ];
+
+  return candidates.find((candidate) => typeof candidate === "string" && candidate.trim().length > 0) ?? null;
+}
+
+function cleanText(value?: string): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeByline(byline?: string): string | undefined {
+  const cleaned = cleanText(byline);
+  if (!cleaned) {
+    return undefined;
+  }
+  return cleaned.replace(/^by\s+/i, "").trim() || undefined;
+}
+
+function articleId(article: EspnArticle, fallbackUrl: string, league: SupportedLeague, index: number): string {
+  const rawId = article.id ?? article.guid ?? `${league}-${index}-${fallbackUrl}`;
+  return String(rawId);
+}
+
+export async function fetchLeagueNews(league: SupportedLeague): Promise<NormalizedNewsArticle[]> {
+  const endpoint = LEAGUE_ENDPOINTS[league];
+
+  if (!endpoint) {
+    return [];
+  }
+
+  try {
+    const response = await fetch(endpoint, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const payload = (await response.json()) as EspnNewsPayload;
+    const rawArticles = Array.isArray(payload.articles)
+      ? payload.articles
+      : Array.isArray(payload.headlines)
+        ? payload.headlines
+        : [];
+
+    return rawArticles
+      .map((article, index) => {
+        const url = extractUrl(article);
+        if (!url) {
+          return null;
+        }
+
+        const title = cleanText(
+          article.headline ?? article.title ?? article.name ?? article.shortHeadline ?? article.summary ?? url,
+        );
+        const summary = cleanText(article.description ?? article.summary ?? article.subtitle);
+        const publishedAt = parseDate(
+          article.published ?? article.publishedAt ?? article.lastModified ?? article.updated ?? article.created ?? article.displayDate,
+        );
+        const author = normalizeByline(article.byline);
+
+        return {
+          id: articleId(article, url, league, index),
+          title: title || url,
+          summary,
+          league,
+          publishedAt,
+          author,
+          url,
+        } satisfies NormalizedNewsArticle;
+      })
+      .filter((article): article is NormalizedNewsArticle => Boolean(article));
+  } catch (error) {
+    console.error(`Failed to load ${league.toUpperCase()} news`, error);
+    return [];
+  }
+}

--- a/tests/lib/news.test.ts
+++ b/tests/lib/news.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchLeagueNews } from "@/lib/news";
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_DATE = Date;
+
+function mockFetchOnce(payload: unknown, init?: { status?: number }) {
+  global.fetch = async () =>
+    new Response(JSON.stringify(payload), {
+      status: init?.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+function restoreFetch() {
+  global.fetch = ORIGINAL_FETCH;
+}
+
+function withFixedDate(value: string) {
+  class FixedDate extends ORIGINAL_DATE {
+    constructor(dateValue?: number | string | Date) {
+      if (dateValue !== undefined) {
+        super(dateValue);
+      } else {
+        super(value);
+      }
+    }
+
+    static now() {
+      return new ORIGINAL_DATE(value).getTime();
+    }
+  }
+
+  global.Date = FixedDate as unknown as typeof Date;
+}
+
+function restoreDate() {
+  global.Date = ORIGINAL_DATE;
+}
+
+test("fetchLeagueNews normalizes ESPN headlines", async (t) => {
+  t.afterEach(() => {
+    restoreFetch();
+    restoreDate();
+  });
+
+  mockFetchOnce({
+    headlines: [
+      {
+        id: "12345",
+        headline: "Ace guards lead Game 1 charge",
+        description: "The defending champions set the tone early in the Finals.",
+        published: "2024-09-01T12:00:00Z",
+        byline: "By Alex Morgan",
+        links: {
+          web: { href: "https://example.com/wnba/game-1" },
+        },
+      },
+    ],
+  });
+
+  const articles = await fetchLeagueNews("wnba");
+  assert.equal(articles.length, 1);
+
+  const article = articles[0];
+  assert.equal(article.id, "12345");
+  assert.equal(article.title, "Ace guards lead Game 1 charge");
+  assert.equal(article.summary, "The defending champions set the tone early in the Finals.");
+  assert.equal(article.league, "wnba");
+  assert.equal(article.publishedAt, "2024-09-01T12:00:00.000Z");
+  assert.equal(article.author, "Alex Morgan");
+  assert.equal(article.url, "https://example.com/wnba/game-1");
+});
+
+test("fetchLeagueNews tolerates missing fields and falls back gracefully", async (t) => {
+  t.afterEach(() => {
+    restoreFetch();
+    restoreDate();
+  });
+
+  withFixedDate("2024-09-02T00:00:00Z");
+
+  mockFetchOnce({
+    articles: [
+      {
+        headline: "Late equalizer shakes up standings",
+        subtitle: "A stoppage-time stunner keeps the playoff race tight.",
+        links: { mobile: { href: "https://example.com/nwsl/highlights" } },
+      },
+    ],
+  });
+
+  const articles = await fetchLeagueNews("nwsl");
+  assert.equal(articles.length, 1);
+
+  const article = articles[0];
+  assert.ok(article.id.startsWith("nwsl-0-https://example.com/nwsl/highlights"));
+  assert.equal(article.summary, "A stoppage-time stunner keeps the playoff race tight.");
+  assert.equal(article.author, undefined);
+  assert.equal(article.publishedAt, new ORIGINAL_DATE("2024-09-02T00:00:00Z").toISOString());
+});
+
+test("fetchLeagueNews filters out entries without a usable URL", async (t) => {
+  t.afterEach(() => {
+    restoreFetch();
+    restoreDate();
+  });
+
+  mockFetchOnce({
+    headlines: [
+      {
+        id: "no-url",
+        headline: "Roster shuffle continues",
+      },
+      {
+        guid: "with-url",
+        headline: "Draft class impresses in preseason",
+        lastModified: "2024-08-21T15:30:00Z",
+        links: { web: { href: "https://example.com/pwhl/draft-class" } },
+      },
+    ],
+  });
+
+  const articles = await fetchLeagueNews("pwhl");
+  assert.equal(articles.length, 1);
+  assert.equal(articles[0]?.id, "with-url");
+  assert.equal(articles[0]?.url, "https://example.com/pwhl/draft-class");
+});


### PR DESCRIPTION
## Summary
- add an ESPN news normalizer for WNBA, NWSL, and PWHL headlines
- update the news API route to fetch, merge, dedupe, and sort normalized articles
- align the news panel with the shared article shape and keep error handling intact

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd93ba6bac832ebbe95a848bd184e2