### PR TITLE
Add babel-loader dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "18.3.0",
     "@testing-library/react": "^14.1.2",
     "autoprefixer": "10.4.20",
+    "babel-loader": "^8.4.1",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.5",
     "jsdom": "^24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.45)
+      babel-loader:
+        specifier: ^8.4.1
+        version: 8.4.1(@babel/core@7.28.4)(webpack@5.102.0)
       eslint:
         specifier: 8.57.1
         version: 8.57.1


### PR DESCRIPTION
## Summary
- add babel-loader as a workspace-level dev dependency
- update the pnpm lockfile to record the new dependency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e083670bb8832ea1117c18df92b1a1