### PR TITLE
Refine news normalization

### DIFF
--- a/lib/news.ts
+++ b/lib/news.ts
@@ -118,33 +118,33 @@ export async function fetchLeagueNews(league: SupportedLeague): Promise<Normaliz
         ? payload.headlines
         : [];
 
-    return rawArticles
-      .map((article, index) => {
-        const url = extractUrl(article);
-        if (!url) {
-          return null;
-        }
+    return rawArticles.flatMap((article, index) => {
+      const url = extractUrl(article);
+      if (!url) {
+        return [];
+      }
 
-        const title = cleanText(
-          article.headline ?? article.title ?? article.name ?? article.shortHeadline ?? article.summary ?? url,
-        );
-        const summary = cleanText(article.description ?? article.summary ?? article.subtitle);
-        const publishedAt = parseDate(
-          article.published ?? article.publishedAt ?? article.lastModified ?? article.updated ?? article.created ?? article.displayDate,
-        );
-        const author = normalizeByline(article.byline);
+      const title = cleanText(
+        article.headline ?? article.title ?? article.name ?? article.shortHeadline ?? article.summary ?? url,
+      );
+      const summary = cleanText(article.description ?? article.summary ?? article.subtitle);
+      const publishedAt = parseDate(
+        article.published ?? article.publishedAt ?? article.lastModified ?? article.updated ?? article.created ?? article.displayDate,
+      );
+      const author = normalizeByline(article.byline);
 
-        return {
-          id: articleId(article, url, league, index),
-          title: title || url,
-          summary,
-          league,
-          publishedAt,
-          author,
-          url,
-        } satisfies NormalizedNewsArticle;
-      })
-      .filter((article): article is NormalizedNewsArticle => Boolean(article));
+      const normalized: NormalizedNewsArticle = {
+        id: articleId(article, url, league, index),
+        title: title || url,
+        summary,
+        league,
+        publishedAt,
+        author,
+        url,
+      };
+
+      return [normalized];
+    });
   } catch (error) {
     console.error(`Failed to load ${league.toUpperCase()} news`, error);
     return [];


### PR DESCRIPTION
## Summary
- switch league news normalization to use flatMap so skipped articles no longer yield nulls
- explicitly type normalized article objects as NormalizedNewsArticle

## Testing
- pnpm run build *(fails: Next.js cannot download Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08694ef1c832ebbb8c052908f9ace