### PR TITLE
Add ambient typing for next-pwa

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "types/**/*.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "**/*.cjs",

--- a/types/next-pwa.d.ts
+++ b/types/next-pwa.d.ts
@@ -1,0 +1,1 @@
+declare module 'next-pwa';


### PR DESCRIPTION
## Summary
- add an ambient declaration so TypeScript recognizes the `next-pwa` module
- extend the TypeScript configuration include paths to cover custom type declarations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e088f96d4c832e8614420f1be6e555