### PR TITLE
Use Vercel CLI for production build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build project
-        run: pnpm build
+      - name: Hydrate Vercel project settings
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build with Vercel CLI
+        run: pnpm dlx vercel@latest build --prod --token ${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel
         uses: vercel/action@v3


### PR DESCRIPTION
## Summary
- hydrate the Vercel project configuration before building in the deploy workflow
- build the project using the Vercel CLI so the prebuilt artifact can be uploaded by the Vercel action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e125db3204832e941c01beadff244a