### PR TITLE
Mark offline page as client component

### DIFF
--- a/app/offline/head.tsx
+++ b/app/offline/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <title>Offline | Raising the Game Scores</title>
+    </>
+  );
+}

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -1,12 +1,6 @@
-import type { Metadata } from "next";
+"use client";
 
 export const dynamic = "error";
-
-export function generateMetadata(): Metadata {
-  return {
-    title: "Offline | Raising the Game Scores",
-  };
-}
 
 export default function OfflinePage() {
   const handleRetry = () => {


### PR DESCRIPTION
## Summary
- add the client component directive to the offline page so its retry logic can run in the browser

## Testing
- pnpm build *(fails: unable to download Google Fonts in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12c903a18832e8d2266305c3bd9d1