### PR TITLE
Move theme color metadata to viewport export

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,6 @@ export const metadata: Metadata = {
   title: "Raising the Game Scores",
   description: "Live scores across the WNBA, NWSL, and PWHL in one place.",
   manifest: "/manifest.webmanifest",
-  themeColor: "#0b0e19",
   icons: {
     icon: "/icons/icon-192x192.png",
     apple: "/icons/apple-icon-180x180.png",
@@ -32,6 +31,8 @@ export const metadata: Metadata = {
     title: "RTG Scores",
   },
 };
+
+export const viewport = { themeColor: "#0b0e19" };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- remove the `themeColor` value from the Next.js metadata export
- expose the theme color through a new `viewport` export as required by Next.js 14

## Testing
- pnpm build *(fails: NextFontError fetching Google Fonts due to network restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12f76e2f8832e8862b604f05d874a